### PR TITLE
bump papermill and JL extension versions

### DIFF
--- a/jupyterlab_primehub/README.md
+++ b/jupyterlab_primehub/README.md
@@ -27,7 +27,7 @@ pip uninstall jupyterlab_primehub
 Example docker file:
 ```dockerfile
 FROM jupyter/base-notebook
-ARG PRIMEHUB_EXTENSION_VERSION="0.1.3"
+ARG PRIMEHUB_EXTENSION_VERSION="0.1.4"
 USER $NB_UID
 RUN pip install --no-cache-dir jupyterlab_primehub~=$PRIMEHUB_EXTENSION_VERSION && \
     jupyter serverextension enable jupyterlab_primehub && \

--- a/jupyterlab_primehub/jupyterlab_primehub/_version.py
+++ b/jupyterlab_primehub/jupyterlab_primehub/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 1, 3)
+version_info = (0, 1, 4)
 __version__ = ".".join(map(str, version_info))

--- a/jupyterlab_primehub/package.json
+++ b/jupyterlab_primehub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infuseai/jupyterlab-primehub",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "PrimeHub extension in jupyterlab",
   "keywords": [
     "jupyter",

--- a/jupyterlab_primehub/setup.py
+++ b/jupyterlab_primehub/setup.py
@@ -65,7 +65,7 @@ setup_args = dict(
     install_requires=[
         "jupyterlab~=2.0",
         "primehub-job",
-        "papermill~=2.1.0"
+        "papermill~=2.3.0"
     ],
     zip_safe=False,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="primehub_job",
-    version="0.1.3",
+    version="0.1.4",
     description="Submit PrimeHub jobs easier",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Signed-off-by: Eric Yang ericy@infuseai.io

- bump papermill to v2.3.3 to avoid `Notebook JSON is invalid: Additional properties are not allowed ('id' was unexpected)` issue
- bump JL extension to v0.1.4
- published to npm and PyPI
